### PR TITLE
Add glycan class statistical analysis and improve outputs

### DIFF
--- a/functions/peptidegroups_modification_stats.R
+++ b/functions/peptidegroups_modification_stats.R
@@ -4,6 +4,8 @@
 library(tidyverse)
 library(ggplot2)
 library(effectsize)
+library(effsize)
+
 
 #' Analyze sample-level fucosylation with statistical tests
 #' 
@@ -11,8 +13,8 @@ library(effectsize)
 #' @param output_dir Directory to save output files
 #' @param figures_dir Directory to save figures
 #' @return List containing fucosylation analysis results
-analyze_sample_fucosylation <- function(data, output_dir = "output_data/peptidegroups_intensity", 
-                                       figures_dir = "figures/peptidegroups_intensity") {
+analyze_sample_fucosylation <- function(data, output_dir = "output_data/peptidegroups_intensity/puesdo_glycomics", 
+                                       figures_dir = "figures/peptidegroups_intensity/puesdo_glycomics") {
   
   # Create output directories if they don't exist
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
@@ -78,15 +80,6 @@ analyze_sample_fucosylation <- function(data, output_dir = "output_data/peptideg
                                       y_var = "fuc_percentage",
                                       output_path = file.path(figures_dir, "fucosylation_comparison.png"))
   
-  # Save detailed summary
-  write.csv(fucosylation_summary, file.path(output_dir, "fucosylation_detailed_summary_with_se.csv"), row.names = FALSE)
-  
-  # Print summary
-  cat("\nFucosylation Analysis Summary:\n")
-  cat("T-test p-value:", t_test_result$p.value, "\n")
-  cat("F-test p-value:", f_p_value, "\n")
-  cat("Cohen's d:", cohens_d_value, "\n")
-  
   # Interpret Cohen's d
   cohens_d_interpretation <- case_when(
     abs(cohens_d_value) < 0.2 ~ "negligible",
@@ -95,6 +88,41 @@ analyze_sample_fucosylation <- function(data, output_dir = "output_data/peptideg
     TRUE ~ "large"
   )
   
+  # Create comprehensive statistical test results
+  # Handle potential missing or differently structured cohens_d_result fields
+  cohens_d_p_value <- if("p_value" %in% names(cohens_d_result)) cohens_d_result$p_value else NA
+  cohens_d_ci_low <- if("CI_low" %in% names(cohens_d_result)) cohens_d_result$CI_low else NA
+  cohens_d_ci_high <- if("CI_high" %in% names(cohens_d_result)) cohens_d_result$CI_high else NA
+  
+  statistical_results <- data.frame(
+    test_type = c("t_test", "f_test", "cohens_d"),
+    statistic_name = c("t_statistic", "f_ratio", "cohens_d"),
+    statistic_value = c(t_test_result$statistic, f_ratio, cohens_d_value),
+    p_value = c(t_test_result$p.value, f_p_value, cohens_d_p_value),
+    df1 = c(t_test_result$parameter, df1, NA),
+    df2 = c(NA, df2, NA),
+    confidence_interval_lower = c(t_test_result$conf.int[1], NA, cohens_d_ci_low),
+    confidence_interval_upper = c(t_test_result$conf.int[2], NA, cohens_d_ci_high),
+    effect_size_interpretation = c(NA, NA, cohens_d_interpretation),
+    description = c("Independent samples t-test comparing fucosylation percentages between groups",
+                   "F-test for homogeneity of variance",
+                   "Cohen's d effect size measure")
+  )
+  
+  # Save detailed summary
+  write.csv(fucosylation_summary, file.path(output_dir, "fucosylation_detailed_summary_with_se.csv"), row.names = FALSE)
+  
+  # Save comprehensive statistical test results
+  write.csv(statistical_results, file.path(output_dir, "fucosylation_statistical_tests_results.csv"), row.names = FALSE)
+  
+  # Save raw sample-level data
+  write.csv(fucosylation_by_sample, file.path(output_dir, "fucosylation_by_sample_data.csv"), row.names = FALSE)
+  
+  # Print summary
+  cat("\nFucosylation Analysis Summary:\n")
+  cat("T-test p-value:", t_test_result$p.value, "\n")
+  cat("F-test p-value:", f_p_value, "\n")
+  cat("Cohen's d:", cohens_d_value, "\n")
   cat("Effect size interpretation:", cohens_d_interpretation, "effect\n")
   
   return(list(
@@ -181,15 +209,6 @@ analyze_sample_sialylation <- function(data, output_dir = "output_data/peptidegr
                                       y_var = "neuac_percentage",
                                       output_path = file.path(figures_dir, "sialylation_comparison.png"))
   
-  # Save detailed summary
-  write.csv(neuac_summary, file.path(output_dir, "sialylation_detailed_summary_with_se.csv"), row.names = FALSE)
-  
-  # Print summary
-  cat("\nSialylation Analysis Summary:\n")
-  cat("T-test p-value:", t_test_result$p.value, "\n")
-  cat("F-test p-value:", f_p_value, "\n")
-  cat("Cohen's d:", cohens_d_value, "\n")
-  
   # Interpret Cohen's d
   cohens_d_interpretation <- case_when(
     abs(cohens_d_value) < 0.2 ~ "negligible",
@@ -198,6 +217,41 @@ analyze_sample_sialylation <- function(data, output_dir = "output_data/peptidegr
     TRUE ~ "large"
   )
   
+  # Create comprehensive statistical test results
+  # Handle potential missing or differently structured cohens_d_result fields
+  cohens_d_p_value <- if("p_value" %in% names(cohens_d_result)) cohens_d_result$p_value else NA
+  cohens_d_ci_low <- if("CI_low" %in% names(cohens_d_result)) cohens_d_result$CI_low else NA
+  cohens_d_ci_high <- if("CI_high" %in% names(cohens_d_result)) cohens_d_result$CI_high else NA
+  
+  statistical_results <- data.frame(
+    test_type = c("t_test", "f_test", "cohens_d"),
+    statistic_name = c("t_statistic", "f_ratio", "cohens_d"),
+    statistic_value = c(t_test_result$statistic, f_ratio, cohens_d_value),
+    p_value = c(t_test_result$p.value, f_p_value, cohens_d_p_value),
+    df1 = c(t_test_result$parameter, df1, NA),
+    df2 = c(NA, df2, NA),
+    confidence_interval_lower = c(t_test_result$conf.int[1], NA, cohens_d_ci_low),
+    confidence_interval_upper = c(t_test_result$conf.int[2], NA, cohens_d_ci_high),
+    effect_size_interpretation = c(NA, NA, cohens_d_interpretation),
+    description = c("Independent samples t-test comparing sialylation percentages between groups",
+                   "F-test for homogeneity of variance",
+                   "Cohen's d effect size measure")
+  )
+  
+  # Save detailed summary
+  write.csv(neuac_summary, file.path(output_dir, "sialylation_detailed_summary_with_se.csv"), row.names = FALSE)
+  
+  # Save comprehensive statistical test results
+  write.csv(statistical_results, file.path(output_dir, "sialylation_statistical_tests_results.csv"), row.names = FALSE)
+  
+  # Save raw sample-level data
+  write.csv(neuac_by_sample, file.path(output_dir, "sialylation_by_sample_data.csv"), row.names = FALSE)
+  
+  # Print summary
+  cat("\nSialylation Analysis Summary:\n")
+  cat("T-test p-value:", t_test_result$p.value, "\n")
+  cat("F-test p-value:", f_p_value, "\n")
+  cat("Cohen's d:", cohens_d_value, "\n")
   cat("Effect size interpretation:", cohens_d_interpretation, "effect\n")
   
   return(list(
@@ -208,6 +262,226 @@ analyze_sample_sialylation <- function(data, output_dir = "output_data/peptidegr
     cohens_d_result = cohens_d_result,
     cohens_d_interpretation = cohens_d_interpretation,
     plots = plots
+  ))
+}
+
+#' Analyze glycan class statistical differences between groups
+#' 
+#' @param data Long format data with abundance, sample, group, glycan_class columns
+#' @param output_dir Directory to save output files
+#' @param figures_dir Directory to save figures
+#' @return List containing glycan class analysis results
+analyze_glycan_class_statistics <- function(data, output_dir = "output_data/peptidegroups_intensity", 
+                                           figures_dir = "figures/peptidegroups_intensity") {
+  
+  # Create output directories if they don't exist
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  dir.create(figures_dir, recursive = TRUE, showWarnings = FALSE)
+  
+  # Calculate glycan class percentages by sample
+  glycan_class_by_sample <- data %>%
+    # Group by sample and group to get total abundance per sample
+    group_by(sample, group) %>%
+    mutate(total_sample_abundance = sum(abundance, na.rm = TRUE)) %>%
+    # Group by glycan class and calculate percentages
+    group_by(sample, group, glycan_class) %>%
+    summarise(
+      class_abundance = sum(abundance, na.rm = TRUE),
+      total_abundance = first(total_sample_abundance),
+      class_percentage = (class_abundance / total_abundance) * 100,
+      .groups = 'drop'
+    )
+  
+  # Perform statistical tests for each glycan class
+  glycan_class_stats <- glycan_class_by_sample %>%
+    group_by(glycan_class) %>%
+    summarise(
+      # Sample sizes
+      n_healthy = sum(group == "Healthy"),
+      n_mecfs = sum(group == "MECFS"),
+      
+      # Descriptive statistics
+      mean_healthy = mean(class_percentage[group == "Healthy"], na.rm = TRUE),
+      mean_mecfs = mean(class_percentage[group == "MECFS"], na.rm = TRUE),
+      sd_healthy = sd(class_percentage[group == "Healthy"], na.rm = TRUE),
+      sd_mecfs = sd(class_percentage[group == "MECFS"], na.rm = TRUE),
+      se_healthy = sd_healthy / sqrt(n_healthy),
+      se_mecfs = sd_mecfs / sqrt(n_mecfs),
+      
+      # Statistical tests
+      t_statistic = tryCatch({
+        t.test(class_percentage ~ group)$statistic
+      }, error = function(e) NA_real_),
+      t_p_value = tryCatch({
+        t.test(class_percentage ~ group)$p.value
+      }, error = function(e) NA_real_),
+      
+      # F-test for variance
+      f_statistic = tryCatch({
+        if(sd_healthy > 0 && sd_mecfs > 0) {
+          var.test(class_percentage ~ group)$statistic
+        } else NA_real_
+      }, error = function(e) NA_real_),
+      f_p_value = tryCatch({
+        if(sd_healthy > 0 && sd_mecfs > 0) {
+          var.test(class_percentage ~ group)$p.value
+        } else NA_real_
+      }, error = function(e) NA_real_),
+      
+      # Cohen's d effect size
+      cohens_d = tryCatch({
+        if(sd_healthy > 0 && sd_mecfs > 0) {
+          cohens_d_result <- cohens_d(class_percentage ~ group)
+          cohens_d_result$Cohens_d
+        } else NA_real_
+      }, error = function(e) NA_real_),
+      
+      .groups = 'drop'
+    ) %>%
+    mutate(
+      # Calculate additional statistics
+      fold_change = mean_mecfs / mean_healthy,
+      log2_fold_change = log2(fold_change),
+      mean_difference = mean_mecfs - mean_healthy,
+      
+      # Effect size interpretation
+      effect_size_interpretation = case_when(
+        is.na(cohens_d) ~ "Cannot calculate",
+        abs(cohens_d) < 0.2 ~ "negligible",
+        abs(cohens_d) < 0.5 ~ "small",
+        abs(cohens_d) < 0.8 ~ "medium",
+        TRUE ~ "large"
+      ),
+      
+      # Significance flags
+      significant_t_test = t_p_value < 0.05 & !is.na(t_p_value),
+      significant_f_test = f_p_value < 0.05 & !is.na(f_p_value),
+      high_fold_change = abs(log2_fold_change) > 1,  # >2-fold or <0.5-fold
+      
+      # Confidence intervals (95%)
+      ci_lower_healthy = mean_healthy - (1.96 * se_healthy),
+      ci_upper_healthy = mean_healthy + (1.96 * se_healthy),
+      ci_lower_mecfs = mean_mecfs - (1.96 * se_mecfs),
+      ci_upper_mecfs = mean_mecfs + (1.96 * se_mecfs)
+    ) %>%
+    arrange(t_p_value)
+  
+  # Apply multiple testing correction
+  glycan_class_stats$t_p_value_adj <- p.adjust(glycan_class_stats$t_p_value, method = "BH")
+  glycan_class_stats$significant_t_test_adj <- glycan_class_stats$t_p_value_adj < 0.05
+  
+  # Create summary statistics by group
+  group_summary <- glycan_class_by_sample %>%
+    group_by(group, glycan_class) %>%
+    summarise(
+      n = n(),
+      mean_percentage = mean(class_percentage, na.rm = TRUE),
+      sd_percentage = sd(class_percentage, na.rm = TRUE),
+      se_percentage = sd_percentage / sqrt(n),
+      median_percentage = median(class_percentage),
+      min_percentage = min(class_percentage),
+      max_percentage = max(class_percentage),
+      .groups = 'drop'
+    ) %>%
+    pivot_wider(names_from = group, 
+                values_from = c(n, mean_percentage, sd_percentage, se_percentage, 
+                               median_percentage, min_percentage, max_percentage),
+                names_sep = "_")
+  
+  # Create comprehensive results table
+  comprehensive_results <- glycan_class_stats %>%
+    left_join(group_summary, by = "glycan_class") %>%
+    select(
+      glycan_class,
+      n_healthy, n_mecfs,
+      mean_healthy, mean_mecfs,
+      sd_healthy, sd_mecfs,
+      se_healthy, se_mecfs,
+      median_percentage_Healthy, median_percentage_MECFS,
+      min_percentage_Healthy, min_percentage_MECFS,
+      max_percentage_Healthy, max_percentage_MECFS,
+      ci_lower_healthy, ci_upper_healthy,
+      ci_lower_mecfs, ci_upper_mecfs,
+      mean_difference, fold_change, log2_fold_change,
+      t_statistic, t_p_value,
+      f_statistic, f_p_value,
+      cohens_d, effect_size_interpretation,
+      significant_t_test, significant_t_test_adj, significant_f_test, high_fold_change
+    )
+  
+  # Save all results
+  write.csv(glycan_class_by_sample, file.path(output_dir, "glycan_class_by_sample_data.csv"), row.names = FALSE)
+  write.csv(glycan_class_stats, file.path(output_dir, "glycan_class_statistical_tests.csv"), row.names = FALSE)
+  write.csv(comprehensive_results, file.path(output_dir, "glycan_class_comprehensive_results.csv"), row.names = FALSE)
+  
+  # Create plots
+  plots <- create_glycan_class_plots(glycan_class_by_sample, glycan_class_stats, figures_dir)
+  
+  # Print summary
+  cat("\nGlycan Class Analysis Summary:\n")
+  cat("Total glycan classes analyzed:", nrow(glycan_class_stats), "\n")
+  cat("Significant differences (p < 0.05):", sum(glycan_class_stats$significant_t_test, na.rm = TRUE), "\n")
+  cat("Significant after multiple testing correction:", sum(glycan_class_stats$significant_t_test_adj, na.rm = TRUE), "\n")
+  cat("High fold changes (>2-fold or <0.5-fold):", sum(glycan_class_stats$high_fold_change, na.rm = TRUE), "\n")
+  
+  # Print significant results
+  significant_classes <- glycan_class_stats %>%
+    filter(significant_t_test_adj) %>%
+    arrange(t_p_value_adj)
+  
+  if(nrow(significant_classes) > 0) {
+    cat("\nSignificantly different glycan classes (after multiple testing correction):\n")
+    for(i in 1:nrow(significant_classes)) {
+      cat(sprintf("\n%d. %s\n", i, significant_classes$glycan_class[i]))
+      cat(sprintf("   Healthy: %.2f%% ± %.2f%% SD\n", 
+                  significant_classes$mean_healthy[i],
+                  significant_classes$sd_healthy[i]))
+      cat(sprintf("   MECFS: %.2f%% ± %.2f%% SD\n", 
+                  significant_classes$mean_mecfs[i],
+                  significant_classes$sd_mecfs[i]))
+      cat(sprintf("   Adjusted p-value: %.3e\n", significant_classes$t_p_value_adj[i]))
+      cat(sprintf("   Fold change: %.2f\n", significant_classes$fold_change[i]))
+      cat(sprintf("   Effect size: %s\n", significant_classes$effect_size_interpretation[i]))
+    }
+  }
+  
+  return(list(
+    glycan_class_by_sample = glycan_class_by_sample,
+    glycan_class_stats = glycan_class_stats,
+    comprehensive_results = comprehensive_results,
+    significant_classes = significant_classes,
+    plots = plots
+  ))
+}
+
+#' Create plots for glycan class analysis
+#' 
+#' @param glycan_class_by_sample Sample-level data
+#' @param glycan_class_stats Statistical results
+#' @param figures_dir Directory to save figures
+#' @return List of ggplot objects
+create_glycan_class_plots <- function(glycan_class_by_sample, glycan_class_stats, figures_dir) {
+  
+  # Create boxplot
+  boxplot <- ggplot(glycan_class_by_sample, aes(x = glycan_class, y = class_percentage, fill = group)) +
+    geom_boxplot(alpha = 0.7, outlier.shape = 1) +
+    geom_jitter(width = 0.2, alpha = 0.6, size = 2) +
+    scale_fill_manual(values = c("Healthy" = "#2E8B57", "MECFS" = "#DC143C")) +
+    labs(title = "Glycan Class Distribution by Group",
+         x = "Glycan Class",
+         y = "Relative Abundance (%)",
+         fill = "Group") +
+    theme_minimal() +
+    theme(axis.text.x = element_text(angle = 45, hjust = 1),
+          plot.title = element_text(hjust = 0.5))
+  
+  # Save boxplot
+  ggsave(file.path(figures_dir, "glycan_class_comparison.png"), boxplot, 
+         width = 12, height = 8, dpi = 300)
+  
+ 
+  return(list(
+    boxplot = boxplot,
   ))
 }
 
@@ -347,39 +621,55 @@ create_modification_boxplot <- function(data, summary_data, t_test_result, f_rat
 }
 
 #' Analyze glycan class relative abundance by sample
-#' 
-#' @param data Long format data with abundance, sample, group, glycan_class columns
-#' @param output_dir Directory to save output files
+#'
+#' @param data Long format data with columns: abundance, sample, group, glycan_class
+#' @param output_dir Directory to save output files (CSVs)
 #' @param figures_dir Directory to save figures
-#' @return List containing glycan class analysis results
-analyze_glycan_class_by_sample <- function(data, output_dir = "output_data/peptidegroups_intensity", 
-                                          figures_dir = "figures") {
-  
-  # Create output directories if they don't exist
+#' @return List with per-sample table, summary table, between-group test table, and ggplot object
+#' @details
+#' - Between-group tests are computed per glycan_class.
+#' - Welch's t-test is used by default (robust to unequal variances).
+#' - F-test (var.test) reports variance ratio (s^2_Healthy / s^2_MECFS).
+#' - Effect size is Hedges' g (bias-corrected Cohen's d).
+#' - If a class has <2 observations in either group, stats are returned as NA.
+analyze_glycan_class_by_sample <- function(data,
+                                           output_dir = "output_data/peptidegroups_intensity",
+                                           figures_dir = "figures") {
+
+  requireNamespace("dplyr", quietly = TRUE)
+  requireNamespace("ggplot2", quietly = TRUE)
+  requireNamespace("purrr", quietly = TRUE)
+  requireNamespace("broom", quietly = TRUE)
+  if (!requireNamespace("effsize", quietly = TRUE)) {
+    stop("Package 'effsize' is required for Hedges' g. Please install.packages('effsize').")
+  }
+
+  library(dplyr)
+  library(ggplot2)
+  library(purrr)
+  library(broom)
+
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
   dir.create(figures_dir, recursive = TRUE, showWarnings = FALSE)
-  
-  # Calculate relative abundance of glycan classes by sample
+
   glycan_class_by_sample <- data %>%
-    # Group by sample, group, and glycan_class to get abundances
     group_by(sample, group, glycan_class) %>%
     summarise(
       group_abundance = sum(abundance, na.rm = TRUE),
       .groups = 'keep'
     ) %>%
-    # Calculate total abundance per sample for percentage
     group_by(sample, group) %>%
     mutate(
       total_sample_abundance = sum(group_abundance, na.rm = TRUE),
       class_percentage = (group_abundance / total_sample_abundance) * 100
     ) %>%
     ungroup()
-  
-  # Create boxplot for glycan classes
-  glycan_class_plot <- ggplot(glycan_class_by_sample, 
+
+  glycan_class_plot <- ggplot(glycan_class_by_sample,
                               aes(x = glycan_class, y = class_percentage, fill = group)) +
     geom_boxplot(alpha = 0.7, outlier.shape = 1, position = position_dodge(0.8)) +
-    geom_jitter(width = 0.2, alpha = 0.6, size = 1.5, position = position_dodge(0.8)) +
+    geom_jitter(alpha = 0.6, size = 1.5,
+                position = position_jitterdodge(dodge.width = 0.8, jitter.width = 0.2)) +
     scale_fill_manual(values = c("Healthy" = "#9DD4CC", "MECFS" = "#E49CB1")) +
     labs(title = "Relative Abundance of Glycan Classes by Group",
          x = "Glycan Class",
@@ -391,31 +681,110 @@ analyze_glycan_class_by_sample <- function(data, output_dir = "output_data/pepti
       plot.title = element_text(hjust = 0.5),
       legend.position = "bottom"
     )
-  
-  # Save the boxplot
-  ggsave(file.path(figures_dir, "glycan_class_by_group_boxplot.png"), glycan_class_plot, 
+
+  ggsave(file.path(figures_dir, "glycan_class_by_group_boxplot.png"), glycan_class_plot,
          width = 12, height = 8, dpi = 300)
-  
-  cat("Glycan class boxplot saved to:", file.path(figures_dir, "glycan_class_by_group_boxplot.png"), "\n")
-  
-  # Calculate summary statistics by glycan class and group
+
+  message("Glycan class boxplot saved to: ",
+          file.path(figures_dir, "glycan_class_by_group_boxplot.png"))
+
   glycan_class_summary <- glycan_class_by_sample %>%
     group_by(glycan_class, group) %>%
     summarise(
-      n = n(),
+      n = dplyr::n(),
       mean_percentage = mean(class_percentage, na.rm = TRUE),
-      sd_percentage = sd(class_percentage, na.rm = TRUE),
-      se_percentage = sd_percentage / sqrt(n),
+      sd_percentage   = sd(class_percentage, na.rm = TRUE),
+      se_percentage   = sd_percentage / sqrt(n),
       median_percentage = median(class_percentage, na.rm = TRUE),
       .groups = 'drop'
     )
-  
-  # Save summary statistics
-  write.csv(glycan_class_summary, file.path(output_dir, "glycan_class_by_group_summary.csv"), row.names = FALSE)
-  
-  return(list(
+
+  write.csv(glycan_class_summary,
+            file.path(output_dir, "glycan_class_by_group_summary.csv"),
+            row.names = FALSE)
+
+  compute_tests <- function(df) {
+    df <- df %>% dplyr::filter(group %in% c("Healthy", "MECFS"))
+
+    n_H <- sum(df$group == "Healthy")
+    n_M <- sum(df$group == "MECFS")
+
+    m_H <- mean(df$class_percentage[df$group == "Healthy"], na.rm = TRUE)
+    m_M <- mean(df$class_percentage[df$group == "MECFS"], na.rm = TRUE)
+    sd_H <- sd(df$class_percentage[df$group == "Healthy"], na.rm = TRUE)
+    sd_M <- sd(df$class_percentage[df$group == "MECFS"], na.rm = TRUE)
+
+    out <- list(
+      n_Healthy = n_H, n_MECFS = n_M,
+      mean_Healthy = m_H, mean_MECFS = m_M,
+      sd_Healthy = sd_H, sd_MECFS = sd_M,
+      t_stat = NA_real_, t_df = NA_real_, t_p_value = NA_real_,
+      t_ci_low = NA_real_, t_ci_high = NA_real_,
+      hedges_g = NA_real_,
+      F_stat = NA_real_, F_num_df = NA_real_, F_den_df = NA_real_, F_p_value = NA_real_
+    )
+
+    if (n_H >= 2 && n_M >= 2 && all(is.finite(df$class_percentage))) {
+      t_res <- tryCatch(
+        t.test(class_percentage ~ group, data = df, var.equal = FALSE, conf.level = 0.95),
+        error = function(e) NULL
+      )
+      if (!is.null(t_res)) {
+        out$t_stat    <- unname(t_res$statistic)
+        out$t_df      <- unname(t_res$parameter)
+        out$t_p_value <- unname(t_res$p.value)
+        out$t_ci_low  <- unname(t_res$conf.int[1])
+        out$t_ci_high <- unname(t_res$conf.int[2])
+      }
+
+      if (is.finite(sd_H) && is.finite(sd_M) && sd_H > 0 && sd_M > 0) {
+        f_res <- tryCatch(
+          var.test(class_percentage ~ group, data = df),
+          error = function(e) NULL
+        )
+        if (!is.null(f_res)) {
+          out$F_stat    <- unname(f_res$statistic)    # s^2_H / s^2_M
+          out$F_num_df  <- unname(f_res$parameter[1]) # df1
+          out$F_den_df  <- unname(f_res$parameter[2]) # df2
+          out$F_p_value <- unname(f_res$p.value)
+        }
+      }
+
+      g_res <- tryCatch(
+        effsize::cohen.d(class_percentage ~ group, data = df,
+                         hedges.correction = TRUE, na.rm = TRUE),
+        error = function(e) NULL
+      )
+      if (!is.null(g_res) && length(g_res$estimate) == 1) {
+        out$hedges_g <- unname(g_res$estimate)
+      }
+    }
+
+    tibble::as_tibble(out)
+  }
+
+  test_results <- glycan_class_by_sample %>%
+    group_by(glycan_class) %>%
+    group_modify(~ compute_tests(.x)) %>%
+    ungroup() %>%
+    mutate(direction = dplyr::case_when(
+      is.finite(mean_Healthy) & is.finite(mean_MECFS) & (mean_MECFS > mean_Healthy) ~ "MECFS>Healthy",
+      is.finite(mean_Healthy) & is.finite(mean_MECFS) & (mean_MECFS < mean_Healthy) ~ "Healthy>MECFS",
+      TRUE ~ NA_character_
+    ))
+
+  out_tests_path <- file.path(output_dir, "glycan_class_between_group_tests.csv")
+  write.csv(test_results, out_tests_path, row.names = FALSE)
+  message("Between-group test results written to: ", out_tests_path)
+
+  list(
     glycan_class_by_sample = glycan_class_by_sample,
-    glycan_class_summary = glycan_class_summary,
+    glycan_class_summary   = glycan_class_summary,
+    glycan_class_tests     = test_results,
     plot = glycan_class_plot
-  ))
+  )
 }
+
+analyze_sample_fucosylation(data = glyco_peptide_groups_long, output_dir = "output_data/peptidegroups_intensity/puesdo_glycomics", figures_dir = "figures/peptidegroups_intensity/puesdo_glycomics")
+analyze_sample_sialylation(data = glyco_peptide_groups_long, output_dir = "output_data/peptidegroups_intensity/puesdo_glycomics", figures_dir = "figures/peptidegroups_intensity/puesdo_glycomics")
+analyze_glycan_class_by_sample(data = glyco_peptide_groups_long, output_dir = "output_data/peptidegroups_intensity/puesdo_glycomics", figures_dir = "figures/peptidegroups_intensity/puesdo_glycomics")

--- a/setup.R
+++ b/setup.R
@@ -11,7 +11,11 @@ required_packages <- c(
   "tidyr",          # For data tidying
   "stringr",        # For string manipulation
   "forcats",        # For factor manipulation
-  "stats"           # For statistical tests (usually included in base R)
+  "stats",          # For statistical tests (usually included in base R)
+  "effectsize",     # For Cohen's d and other effect size calculations
+  "effsize",        # For Hedges' g and other effect size calculations
+  "broom",          # For tidying statistical test results
+  "janitor"         # For data cleaning functions
 )
 
 # Function to install missing packages


### PR DESCRIPTION
Introduces analyze_glycan_class_statistics and enhances glycan class analysis with comprehensive statistical tests, multiple testing correction, and improved output tables and plots. Also updates output directories for fucosylation and sialylation analyses, adds new dependencies (effsize, broom, janitor) to setup, and refines summary and test result saving for all modification analyses.